### PR TITLE
Version bump 1.0.0

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -43,7 +43,7 @@
     <!-- my styles -->
     <link href="../css/styles.css" rel="stylesheet">
 
-    <title>CRIPT Excel Uploader - version 0.6.4</title>
+    <title>CRIPT Excel Uploader - version 1.0.0</title>
 </head>
 <body>
 <header>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -43,7 +43,7 @@
     <!-- my styles -->
     <link href="../css/styles.css" rel="stylesheet">
 
-    <title>CRIPT Excel Uploader - version 0.6.3</title>
+    <title>CRIPT Excel Uploader - version 0.6.4</title>
 </head>
 <body>
 <header>


### PR DESCRIPTION
> Note: this is only bumping the version text on the executable. Another version bump will be needed from develop to master to get a new release

version bump because next release would have

* Mac executable
* property methods and process methods
    * process methods options are much more built out
    * added more options to material