### PR TITLE
added GitHub discussions link within FAQ for users to submit questions

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,3 +28,6 @@
         1. _inputting your data directly into [CRIPT](https://criptapp.org) via the user interface_
         2. _using the [CRIPT Python SDK](https://pypi.org/project/cript/) to programmatically upload your data to [CRIPT](https://criptapp.org)_
         3. _getting existing CRIPT Scripts and CRIPT Sheets from [criptscripts.org](https://criptscripts.org)_
+
+* **Where is the best place where I can contact the CRIPT Excel Uploader team for questions or support?**
+    * _We would love to hear from you! If you have any questions, need help, or just want to make suggestions for the CRIPT Excel Uploader, we would love to hear it! Please visit our [CRIPT Excel Uploader Repository GitHub Discussions](https://github.com/C-Accel-CRIPT/cript-excel-uploader/discussions) to easily send us questions. A GitHub account is required._


### PR DESCRIPTION
# Description

I think having users post their questions on the [CRIPT Excel Uploader repo discussions](https://github.com/C-Accel-CRIPT/cript-excel-uploader/discussions) can be beneficial so users can browse through previous questions and the community can learn from each other.

Unfortunately, this would require a GitHub account and non-technical users would have to be on a technical platform, but I think it shouldn't be too bad and we can try it and see how it goes. The other choice is for us to [allow comments on our documentation](https://squidfunk.github.io/mkdocs-material/setup/adding-a-comment-system/) I think we might need to setup a way for us to get pinged once a question is posted by a user so we can respond to it. 

However, GitHub has already built out all of this and is easy to manage, so we can easily use it for now.